### PR TITLE
Implements rol.equals() and rol.is(Roles)

### DIFF
--- a/app/controllers/Authentication.java
+++ b/app/controllers/Authentication.java
@@ -3,16 +3,12 @@ package controllers;
 import play.Play;
 import play.mvc.Controller;
 import play.mvc.Result;
-import play.mvc.Http.Context;
 import play.data.DynamicForm;
 import play.data.Form;
 import play.libs.Json;
 import models.User;
 import utils.Crypto;
 
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.io.UnsupportedEncodingException;
 
 public class Authentication extends Controller {
   

--- a/app/models/Rol.java
+++ b/app/models/Rol.java
@@ -10,7 +10,7 @@ import javax.persistence.Id;
 public class Rol extends Model
 {
     @Id
-    public Long id;
+    public long id;
     public String name;
 
     public String getName()
@@ -18,6 +18,33 @@ public class Rol extends Model
         return name;
     }
    
+    @Override
+    public boolean equals(Object that) {
+     if (that == null)
+    	 return false;
+     if (that == this)
+    	 return true;
+     if (!(that instanceof Rol))
+    	 return false;
+     Rol thatRol = (Rol) that;
+     if (this.id != thatRol.id)
+    	 return false;
+     if (this.name == null || !this.name.equals(thatRol.name))
+    	 return false;
+    return true;
+    }
+    
+    @Override
+    public int hashCode() {
+    	/* An initial value for a hashCode, to which is added contributions
+    	   from fields. Using a non-zero value decreases collisons of hashCode
+    	   values. */
+	      int result = 17;
+	      result = 31 * result + (int)( this.id ^ (this.id >>> 32) );
+	      result = 31 * result + (this.name != null ? this.name.hashCode() : 0);
+	      return result;
+     }
+    
     // Statics
     public static final Finder<Long, Rol> find = new Finder<Long, Rol>(Long.class,Rol.class);
 
@@ -27,4 +54,10 @@ public class Rol extends Model
                    .eq("name",role.getName())
                    .findUnique();
     }
+
+	public boolean is(Roles rol) {
+		return this.getName().equals(rol.getName());
+	}
+    
+    
 }

--- a/app/security/RestrictToAction.java
+++ b/app/security/RestrictToAction.java
@@ -9,9 +9,6 @@ import models.Rol;
 import models.User;
 import controllers.Authentication;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 public class RestrictToAction extends Action<RestrictTo>
@@ -36,8 +33,7 @@ public class RestrictToAction extends Action<RestrictTo>
 	            for (Rol userRole : userRoles)
 	            {
 	            	//User is authorized, continue execution.
-	            	// TODO: implements rol.equals()
-	                if (userRole.getName().equals(rol.getName()))
+	                if (userRole.is(rol))
 	                	return delegate.call(context);
 	            }
 	        }

--- a/app/security/Roles.java
+++ b/app/security/Roles.java
@@ -1,8 +1,7 @@
 package security;
 
-import com.avaje.ebean.annotation.EnumMapping;
+import models.Rol;
 
-@EnumMapping(nameValuePairs="SELLER=S, BUYER=B, ADMIN=A")
 public enum Roles
 {
 	SELLER,

--- a/app/security/Roles.java
+++ b/app/security/Roles.java
@@ -1,7 +1,5 @@
 package security;
 
-import models.Rol;
-
 public enum Roles
 {
 	SELLER,


### PR DESCRIPTION
Implements rol.equals() to enable storing rol's instance in set and collections, and rol.is(Roles) to avoid comparing enums name and clases members directly.
