### PR TITLE
loading button when getting commissions details

### DIFF
--- a/public/html/dashboard.html
+++ b/public/html/dashboard.html
@@ -6,7 +6,7 @@
     <p>Recuerde que de superar los $200 de comisión no podrá seguir vendiendo sus productos.</p>
     <span id="commission" style="padding-top:40px; font-family: 'vivaldi'; font-size: 80px;color: #2974B9; letter-spacing: 3px;"></span>
 	<div style="padding-top:40px;" align="right">
-    	<p><a id="payButton" style="text-indent: 0cm;" class="btn btn-primary btn-large">Pagar ahora »</a></p>
+    	<p><button id="payButton" style="text-indent: 0cm;" data-loading-text="Obteniendo comisiones.." class="btn btn-primary btn-large">Pagar ahora »</button></p>
   
 </div>
   </div>

--- a/public/js/sellerDashboards/dashboard.js
+++ b/public/js/sellerDashboards/dashboard.js
@@ -21,10 +21,12 @@ $('#payButton').click(function(){
 
 function seeCommissionDetail(){
 	if( $('#commissionDetailModal').find('table').size() == 0 ) {
+		$("#payButton").button('loading');
 		jsRoutes.controllers.SellerController.commissionDetail().ajax({
  			success: 
 			function(details){
 				addDetailTable(details);
+				$("#payButton").button('reset');
 				$('#commissionDetailModal').modal('show');
 				
 			}


### PR DESCRIPTION
Botón con estado en "Pagar ahora" de comisiones, sino era posible apretar el botón nuevamente antes de que vuelva el resultado del request y se veía duplicada la tabla en el modal.
